### PR TITLE
Add modman file

### DIFF
--- a/build/app/code/community/Symmetrics/Buyerprotect/Helper/Data.php
+++ b/build/app/code/community/Symmetrics/Buyerprotect/Helper/Data.php
@@ -87,6 +87,10 @@ class Symmetrics_Buyerprotect_Helper_Data
 
         /* @var $cartItems Mage_Sales_Model_Mysql4_Quote_Item_Collection */
         $cartItems = $cart->getItems();
+
+        if(!is_object($cartItems)){
+            return false;
+        }
         /* @var $tsIdsSelect Varien_Db_Select */
         $tsIdsSelect = clone $cartItems->getSelect();
         $tsIdsSelect->where('product_type = ?', Symmetrics_Buyerprotect_Model_Type_Buyerprotect::TYPE_BUYERPROTECT);

--- a/modman
+++ b/modman
@@ -1,0 +1,21 @@
+build/app/etc/modules/Symmetrics_Buyerprotect.xml app/etc/modules/Symmetrics_Buyerprotect.xml
+
+build/app/code/community/Symmetrics/Buyerprotect app/code/community/Symmetrics/Buyerprotect
+
+build/app/design/adminhtml/default/default/template/buyerprotect app/design/adminhtml/default/default/template/buyerprotect
+build/app/design/adminhtml/default/default/layout/buyerprotect.xml app/design/adminhtml/default/default/layout/buyerprotect.xml
+build/app/design/frontend/base/default/template/buyerprotect app/design/frontend/default/default/template/buyerprotect
+build/app/design/frontend/base/default/layout/buyerprotect.xml app/design/frontend/default/default/layout/buyerprotect.xml
+
+build/js/symmetrics/* js/symmetrics/
+
+build/skin/adminhtml/default/default/css/buyerprotect.css skin/adminhtml/default/default/css/buyerprotect.css
+build/skin/adminhtml/default/default/images/buyerprotect skin/adminhtml/default/default/images/buyerprotect
+build/skin/frontend/base/default/css/buyerprotect.css skin/frontend/default/default/css/buyerprotect.css
+build/skin/frontend/base/default/images/buyerprotect skin/frontend/default/default/images/buyerprotect
+
+build/app/locale/pl_PL/Symmetrics_Buyerprotect.csv app/locale/pl_PL/Symmetrics_Buyerprotect.csv
+build/app/locale/de_DE/Symmetrics_Buyerprotect.csv app/locale/de_DE/Symmetrics_Buyerprotect.csv
+build/app/locale/en_UK/Symmetrics_Buyerprotect.csv app/locale/en_UK/Symmetrics_Buyerprotect.csv
+build/app/locale/es_ES/Symmetrics_Buyerprotect.csv app/locale/es_ES/Symmetrics_Buyerprotect.csv
+build/app/locale/fr_FR/Symmetrics_Buyerprotect.csv app/locale/fr_FR/Symmetrics_Buyerprotect.csv


### PR DESCRIPTION
Please include modman file. I allows developers to separate magento modules code from magento core. See: http://colin.mollenhour.com/2009/10/17/module-manager-for-when-svnexternals-just-doesnt-cut-it/