### PR TITLE
[~BUGFIX] $file in Mage_Core_Model_Resource_Setup overwritten

### DIFF
--- a/build/app/code/community/Symmetrics/Buyerprotect/sql/buyerprotect_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/build/app/code/community/Symmetrics/Buyerprotect/sql/buyerprotect_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -41,11 +41,12 @@ $emailTemplates = array(
 );
 
 foreach ($emailTemplates as $fileName => $template) {
-    $file = Mage::getBaseDir() . $templatePath . $fileName . $templateSuffix;
-    $content = file_get_contents($file);
+    $templateFile = Mage::getBaseDir() . $templatePath . $fileName . $templateSuffix;
+    $content = file_get_contents($templateFile);
     $template['template_text'] = $content;
 
     $this->createEmailTemplate($template['template_code'], $template);
 }
 
 $this->endSetup();
+

--- a/build/app/code/community/Symmetrics/Buyerprotect/sql/buyerprotect_setup/mysql4-upgrade-0.1.1-0.1.3.php
+++ b/build/app/code/community/Symmetrics/Buyerprotect/sql/buyerprotect_setup/mysql4-upgrade-0.1.1-0.1.3.php
@@ -41,11 +41,12 @@ $emailTemplates = array(
 );
 
 foreach ($emailTemplates as $fileName => $template) {
-    $file = Mage::getBaseDir() . $templatePath . $fileName . $templateSuffix;
-    $content = file_get_contents($file);
+    $templateFile = Mage::getBaseDir() . $templatePath . $fileName . $templateSuffix;
+    $content = file_get_contents($templateFile);
     $template['template_text'] = $content;
 
     $this->updateEmailTemplate($template['template_code'], $template);
 }
 
 $this->endSetup();
+


### PR DESCRIPTION
If $file is used in a setup resource it modifies the $file variable in resource setup class.
I got a warning which causes an exception during unit tests.