### PR TITLE
Workarround for mage core bug

### DIFF
--- a/build/app/code/community/Symmetrics/Buyerprotect/sql/buyerprotect_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/build/app/code/community/Symmetrics/Buyerprotect/sql/buyerprotect_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -41,8 +41,8 @@ $emailTemplates = array(
 );
 
 foreach ($emailTemplates as $fileName => $template) {
-    $file = Mage::getBaseDir() . $templatePath . $fileName . $templateSuffix;
-    $content = file_get_contents($file);
+    $fullFileName = Mage::getBaseDir() . $templatePath . $fileName . $templateSuffix;
+    $content = file_get_contents($fullFileName);
     $template['template_text'] = $content;
 
     $this->createEmailTemplate($template['template_code'], $template);


### PR DESCRIPTION
In Mage_Core_Model_Resource_Setup in Line 624, setup gets included. This causes problems when variables are named similar as in setup scripts. This is a known bug. Changing $file into $fullFileName fixes this problem.

Greeitngs

David